### PR TITLE
Added a more descriptive error message when "category" is omitted

### DIFF
--- a/lib/theo.js
+++ b/lib/theo.js
@@ -53,6 +53,9 @@ handlebars.registerHelper('addOptionalEM', function(value) {
 function addThemeCategories(json) {
   var hasCategory = json.theme.hasCategory = {};
   json.theme.properties.forEach(function(property) {
+    if (property.category === undefined) {
+      throw new Error(util.format('%s did not contain a "category" property', property.name));
+    }
     var category = theoUtil.camelCase(property.category);
     // For use int the handlebars template
     if (hasCategory[category] === undefined) {

--- a/test/mock/error/missing_category.json
+++ b/test/mock/error/missing_category.json
@@ -1,0 +1,29 @@
+{
+  "theme": {
+    "name": "S1 base",
+    "aliases": "aliases.json",
+    "properties": [
+      {
+        "name": "STAGE_LEFT_WIDTH",
+        "value": "88%",
+        "category": "misc",
+        "comment": "NOTE: This is also in oneHelper.js for JavaScript, if you change this, change that."
+      },
+      {
+        "name":"SLIDE_DURATION",
+        "value":"0.25s",
+        "comment": "NOTE: This is also in oneHelper.js for JavaScript, if you change this, change that."
+      },
+      {
+        "name":"LINE_HEIGHT_MEDIUM",
+        "value":"1.25",
+        "category": "line-height"
+      },
+      {
+        "name":"SHADOW_STRONG",
+        "value":"0 1px 3px {!black20}",
+        "category": "drop-shadow"
+      }
+    ]
+  }
+}

--- a/test/theoTest.js
+++ b/test/theoTest.js
@@ -108,6 +108,14 @@ describe('theo', function() {
         }).should.throw();        
       });
 
+      it('throw an error if any properties are missing categories', function () {
+        (function() {
+          theo.convert('./test/mock/error/missing_category.json', './dist', {
+            templates:['less']
+          });
+        }).should.throw(/\w+ did not contain a "category" property/);
+      });
+
       it('search the "templatesDirectory" for templates', function() {
         var foo = path.resolve(__dirname, 'mock/templates/foo.hbs');
         fs.writeFileSync(foo, '');


### PR DESCRIPTION
Whilst testing Theo, I was getting the following error when running gulp...

```
Cannot call method 'toLowerCase' of undefined
```

I had to dig through the source to find out it was because i'd forgotten to add a "category" to a style property. I felt a more descriptive error would have saved me some time troubleshooting the issue, so made this PR. 

Example output:

```
COLOR_INDIGO_DARK did not contain a "category" property
```
