### PR TITLE
Add font weight category

### DIFF
--- a/src/props/formats/html.jsx
+++ b/src/props/formats/html.jsx
@@ -141,6 +141,17 @@ let Styleguide = React.createClass({
     })
   },
 
+  renderFontWeight(props) {
+    return props.map(prop => {
+      let example = (
+        <ExampleRow>
+          <div style={{fontWeight:prop.value}}>Aa</div>
+        </ExampleRow>
+      );
+      return this.renderRow(prop, example);
+    })
+  },
+
   renderFontSize(props) {
     return props.map(prop => {
       let example = (
@@ -251,6 +262,7 @@ let Styleguide = React.createClass({
                   {this.renderSection('drop-shadow', 'Drop Shadows')}
                   {this.renderSection('inner-shadow', 'Inner Drop Shadows', this.renderDropShadow)}
                   {this.renderSection('font', 'Fonts')}
+                  {this.renderSection('font-weight', 'Font Weights')}
                   {this.renderSection('font-size', 'Font Sizes')}
                   {this.renderSection('line-height', 'Line Heights')}
                   {this.renderSection('spacing', 'Spacing')}


### PR DESCRIPTION
Until the Marketing Cloud starts uses SF Sans, we will need font weights. Adds font weight category to Theo. 

May be unrelated, but the current Theo output to HTML appears to be producing something like this:
![screen shot 2015-09-01 at 4 13 29 pm](https://cloud.githubusercontent.com/assets/1290832/9615308/5879ad74-50c5-11e5-9b56-5ce68407ac22.png)

![screen shot 2015-09-01 at 4 13 38 pm](https://cloud.githubusercontent.com/assets/1290832/9615312/5b0ad3e2-50c5-11e5-84b3-3146145959b3.png)

_however this is from the SLDS site_

