### PR TITLE
Register new Theo formats associated with leveraging CSS custom properties

### DIFF
--- a/src/props/index.js
+++ b/src/props/index.js
@@ -205,7 +205,7 @@ registerFormat('custom-properties.css', json => {
   } ).join('\n');
 });
 
-registerFormat('global.custom-properties.css', json => {
+registerFormat('default.custom-properties.css', json => {
   const computedCustomProps = _.map( json.props, prop => {
     const name = kebabCase(prop.name);
     return `--${name}: ${prop.value};`;

--- a/src/props/index.js
+++ b/src/props/index.js
@@ -198,6 +198,27 @@ registerFormat('android.xml', json => {
   return cleanOutput(xml);
 });
 
+registerFormat('custom-properties.css', json => {
+  return _.map( json.props, prop => {
+    const name = kebabCase(prop.name);
+    return `--${name}: ${prop.value};`
+  } ).join('\n')
+});
+
+registerFormat('global.custom-properties.css', json => {
+  const computedCustomProperties = _.map( json.props, prop => {
+    const name = kebabCase(prop.name);
+    return `--${name}: ${prop.value};`;
+  } ).join('\n')
+
+  return `
+    :root {
+      ${computedCustomProperties}
+    }
+  `;
+
+})
+
 registerFormat('scss', json => {
   return _.map(json.props, prop => {
     let name = kebabCase(prop.name);

--- a/src/props/index.js
+++ b/src/props/index.js
@@ -202,22 +202,38 @@ registerFormat('custom-properties.css', json => {
   return _.map( json.props, prop => {
     const name = kebabCase(prop.name);
     return `--${name}: ${prop.value};`
-  } ).join('\n')
+  } ).join('\n');
 });
 
 registerFormat('global.custom-properties.css', json => {
-  const computedCustomProperties = _.map( json.props, prop => {
+  const computedCustomProps = _.map( json.props, prop => {
     const name = kebabCase(prop.name);
     return `--${name}: ${prop.value};`;
-  } ).join('\n')
+  } ).join('\n');
 
   return `
     :root {
-      ${computedCustomProperties}
+      ${computedCustomProps}
     }
   `;
 
-})
+});
+
+
+registerFormat('custom-properties.scss', json => {
+  const computedSCSSVars = _.map( json.props, prop => {
+    const name = kebabCase(prop.name);
+    return `$${name}: ${prop.value};`;
+  } ).join('\n');
+
+  const computedCustomProps = _.map( json.props, prop => {
+    const name = kebabCase(prop.name);
+    return `--${name}: ${prop.value};`;
+  } ).join('\n');
+
+  return `${computedSCSSVars}\n\n${computedCustomProps}`;
+
+});
 
 registerFormat('scss', json => {
   return _.map(json.props, prop => {

--- a/src/props/index.js
+++ b/src/props/index.js
@@ -219,7 +219,6 @@ registerFormat('global.custom-properties.css', json => {
 
 });
 
-
 registerFormat('custom-properties.scss', json => {
   const computedSCSSVars = _.map( json.props, prop => {
     const name = kebabCase(prop.name);


### PR DESCRIPTION
## PR Aims
- [x] Add a default CSS Custom Properties Formatter 
- [x] Add a Theo formatter for CSS Custom Properties for the usual common default of setting it as "default" values using `:root` that's similar to the existing `default.scss` Theo formatter
- [ ] Ensure the new formats comply with the explicit/implicit code conventions of the current file 
- [ ] Ensure tests are written that conform to the current expectations of Theo contributors
## Important things to be discussed and thought about with the review
- Is the naming of the new formatters sensical?
- Is the formatter associated with SCSS variables & the CSS custom property versions of such variables of value as I think it is? 
- Need guidance on the test conventions to write the tests or is someone already assigned to do for other contributors? 
## Estimated Review TIme

Since no tests were written yet because of questions of how it's done in this repo and an understanding of [CSS custom properties](https://www.w3.org/TR/css-variables/) and [how Sass handles CSS custom properties moving forward](https://github.com/sass/sass/issues/1128) , I expect the estimated review time being **10-15-25 minutes** 
## Recommended reviewers
- @kaelig, being involved with the changed files
- @jina, being a Sass Jedi (very knowledgeable about Sass and the most inclusive patterns towards using it well)
- Other core contributors since this adds new default formatters that may not be named at this time in a matter that may not make sense yet to the vision of Theo being the awesome thing it is at the moment. 
