### PR TITLE
Adjusted _resolveAliases to allow for object aliases

### DIFF
--- a/src/props/prop-set.js
+++ b/src/props/prop-set.js
@@ -136,8 +136,10 @@ class PropSet {
         if (_.isString(prop.value)) {
           // Value contains an alias
           if (isAlias.test(prop.value)) {
+            // Determine if alias value is string or object
+            let aliasValue = _.isString(value) ? value : value.value
             // Resolve the alias
-            prop.value = prop.value.replace(isAlias, value)
+            prop.value = prop.value.replace(isAlias, aliasValue)
           }
           if (isAliasStructure.test(prop.value)) {
             _.forEach(prop.value.match(isAliasStructure), a => {


### PR DESCRIPTION
When resolving aliases I added a check to see if alias value was a string, otherwise it uses the `value` key, mimicking the props data structure.

We want to do this because some sets of aliases need additional meta data that we'll be using to check a11y. 

Something like: 

```
aliases:
  foreground:
    value: white
    contrastsTo: background
  background:
    value: black
```

This also allows for better meta data when documenting all of your aliases.
