### PR TITLE
JSON Preprocess function for things like nested props

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Include raw value in prop object as `prop['.rawValue']`
 Don't remove ".meta" key from a prop
 
 **@param {function} [options.jsonPreProcess]**
-A function that is fired before each file is merged into the property set. Should return an object representing the modified JSON data.
+A function that is ran before each yaml/json file is merged. Should return an object representing the modified JSON data.
 
 #### Example:
 
@@ -186,6 +186,7 @@ gulp.src('./design/props.json')
     includeRawValue: true,
     jsonPreProcess: function (json) {
       json.global.category = 'someCategory'
+      return json
     } 
   }))
 ```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ A function that is ran before each yaml/json file is merged. Should return an ob
 gulp.src('./design/props.json')
   .pipe(theo.plugins.transform('web', { 
     includeRawValue: true,
-    jsonPreProcess: function (json) {
+    jsonPreProcess: json => {
       json.global.category = 'someCategory'
       return json
     } 

--- a/README.md
+++ b/README.md
@@ -175,11 +175,19 @@ Include raw value in prop object as `prop['.rawValue']`
 **@param {boolean} [options.includeMeta]**
 Don't remove ".meta" key from a prop
 
+**@param {function} [options.jsonPreProcess]**
+A function that is fired before each file is merged into the property set. Should return an object representing the modified JSON data.
+
 #### Example:
 
 ```js
 gulp.src('./design/props.json')
-  .pipe(theo.plugins.transform('web', { includeRawValue: true }))
+  .pipe(theo.plugins.transform('web', { 
+    includeRawValue: true,
+    jsonPreProcess: function (json) {
+      json.global.category = 'someCategory'
+    } 
+  }))
 ```
 
 ***

--- a/src/props/prop-set.js
+++ b/src/props/prop-set.js
@@ -61,7 +61,6 @@ class PropSet {
         prop['.rawValue'] = _.merge({}, prop).value
       })
     }
-
     // Globals
     this._resolveGlobals(def)
     // Validate

--- a/src/props/prop-set.js
+++ b/src/props/prop-set.js
@@ -48,6 +48,9 @@ class PropSet {
     // Merge the JSON into the definition
     try {
       let json = util.parsePropsFile(this.file)
+      if (options.jsonPreProcess) {
+        json = options.jsonPreProcess(json)
+      }
       def = _.merge(def, json)
     } catch (e) {
       throw TheoError(`transform() encountered an invalid Design Token file: ${this.file.path}`)
@@ -58,6 +61,7 @@ class PropSet {
         prop['.rawValue'] = _.merge({}, prop).value
       })
     }
+
     // Globals
     this._resolveGlobals(def)
     // Validate

--- a/test/props/index.js
+++ b/test/props/index.js
@@ -235,6 +235,19 @@ describe('$props.plugins', () => {
           done()
         }))
     })
+    it('transforms accepts a jsonPreProcess function', (done) => {
+      gulp.src(path.resolve(__dirname, 'mock', 'sample.json'))
+        .pipe($props.plugins.transform('web', {
+          jsonPreProcess: function (json) {
+            json.props.spacing_xx_small.label = 'xx_small'
+            return json
+          }
+        }))
+        .pipe($props.plugins.getResult((result) => {
+          assert.strictEqual(JSON.parse(result).props.spacing_xx_small.label, 'xx_small')
+          done()
+        }))
+    })
   })
 
   describe('#format', () => {


### PR DESCRIPTION
Still need to write up tests/docs, but wanted to make sure the placement and name of this function works for you. I was able to get my nested props function working just fine with this.

```js
      jsonPreProcess: function (json) {
        let resolveNestedProps = function (props, parent = "") {
          let flatProps = {};
          _.forEach(props, (value, key) => {
            if (typeof value !== 'string') {
              let propName = (parent === "" ? "" : parent + "_") + key
              flatProps = Object.assign(flatProps, resolveNestedProps(value, propName))
              flatProps[propName] = value
            }
          })
          return flatProps;
        }
        json.props = resolveNestedProps(json.props);
        return json;
      }
```

Might consider dropping this into a small NPM module if others would like to easily use it. 