### PR TITLE
Add JSON5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ A function that is ran before each YAML/JSON file is merged. Should return an ob
 
 ```js
 gulp.src('./design/props.json')
-  .pipe(theo.plugins.transform('web', { 
+  .pipe(theo.plugins.transform('web', {
     includeRawValue: true,
     jsonPreProcess: json => {
       json.global.category = 'someCategory'
       return json
-    } 
+    }
   }))
 ```
 
@@ -392,7 +392,7 @@ Here is the layout of the `json` argument
 
 ###### raw.json
 
-```json
+```json5
 {
   "props": {
     "PROP_NAME": {
@@ -406,7 +406,7 @@ Here is the layout of the `json` argument
 
 ###### ios.json
 
-```json
+```json5
 {
   "properties": [
     {

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@
 Beta releases are available on npm and release notes are available here: <https://github.com/salesforce-ux/theo/releases>
 
 - Support for `*.yaml` files ([#60](https://github.com/salesforce-ux/theo/issues/60))
+- Support for [JSON5](http://json5.org/) syntax (an improvement on JSON)
 - Improved styleguide theme ([#56](https://github.com/salesforce-ux/theo/pull/56))
 - Aliases can reference other aliases ([#69](https://github.com/salesforce-ux/theo/pull/69))
 - Users may now pre-process the input with custom functions ([#71](https://github.com/salesforce-ux/theo/pull/71))

--- a/src/props/index.js
+++ b/src/props/index.js
@@ -17,6 +17,7 @@ let _ = require('lodash')
 let through = require('through2')
 let gutil = require('gulp-util')
 let tinycolor = require('tinycolor2')
+let JSON5 = require('json5')
 
 let util = require('./util')
 let constants = require('./util/constants')
@@ -162,11 +163,11 @@ registerFormat('json', json => {
   _.forEach(json.props, prop => {
     output[prop.name] = prop.value
   })
-  return JSON.stringify(output, null, 2)
+  return JSON5.stringify(output, null, 2)
 })
 
 registerFormat('raw.json', json => {
-  return JSON.stringify(json, null, 2)
+  return JSON5.stringify(json, null, 2)
 })
 
 registerFormat('ios.json', json => {
@@ -176,7 +177,7 @@ registerFormat('ios.json', json => {
       return prop
     })
   }
-  return JSON.stringify(output, null, 2)
+  return JSON5.stringify(output, null, 2)
 })
 
 registerFormat('android.xml', json => {

--- a/src/props/prop-set.js
+++ b/src/props/prop-set.js
@@ -12,6 +12,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 let path = require('path')
 let fs = require('fs')
+let JSON5 = require('json5')
 let _ = require('lodash')
 let gutil = require('gulp-util')
 let util = require('./util')
@@ -100,7 +101,7 @@ class PropSet {
     // Provide the keys for easy iteration
     def.propKeys = _.keys(def.props)
     // Go
-    return JSON.stringify(def, null, 2)
+    return JSON5.stringify(def, null, 2)
   }
 
   _resolveGlobals (def) {

--- a/src/props/util/index.js
+++ b/src/props/util/index.js
@@ -11,6 +11,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 */
 
 let yaml = require('js-yaml')
+let JSON5 = require('json5')
 let path = require('path')
 
 module.exports = {
@@ -29,7 +30,7 @@ module.exports = {
       case '.yml':
         return yaml.safeLoad(file.contents.toString())
       default:
-        return JSON.parse(file.contents.toString())
+        return JSON5.parse(file.contents.toString())
     }
   }
 

--- a/src/stream-util/index.js
+++ b/src/stream-util/index.js
@@ -14,6 +14,7 @@ let path = require('path')
 let _ = require('lodash')
 let through = require('through2')
 let gutil = require('gulp-util')
+let JSON5 = require('json5')
 
 module.exports = {
 
@@ -108,7 +109,7 @@ module.exports = {
     function flush (next) {
       let file = new gutil.File({
         path: `${options.name}.json`,
-        contents: new Buffer(JSON.stringify(json, null, 2))
+        contents: new Buffer(JSON5.stringify(json, null, 2))
       })
       this.push(file)
       next()
@@ -150,7 +151,7 @@ module.exports = {
       let ext = path.extname(file.relative)
       if (ext === '.json') {
         try {
-          let json = JSON.parse(file.contents.toString())
+          let json = JSON5.parse(file.contents.toString())
           items.push(json)
         } catch (e) {
           let err = new Error('mergeJSON() encountered an invalid JSON file', file.path)
@@ -163,7 +164,7 @@ module.exports = {
       let content = _.merge.apply(null, items)
       let file = new gutil.File({
         path: `${options.name}.json`,
-        contents: new Buffer(JSON.stringify(content, null, 2))
+        contents: new Buffer(JSON5.stringify(content, null, 2))
       })
       this.push(file)
       next()
@@ -199,7 +200,7 @@ module.exports = {
         return next(new Error('parseJSON() encountered on non ".json" file'))
       }
       try {
-        let json = JSON.parse(file.contents.toString())
+        let json = JSON5.parse(file.contents.toString())
         if (typeof callback === 'function') {
           callback(json)
         }

--- a/test/props/index.js
+++ b/test/props/index.js
@@ -22,6 +22,7 @@ const gutil = require('gulp-util')
 const through = require('through2')
 const _ = require('lodash')
 const xml2js = require('xml2js')
+const JSON5 = require('json5')
 
 const $stream = require('../../dist/stream-util')
 const $props = require('../../dist/props')
@@ -205,7 +206,7 @@ describe('$props.plugins', () => {
         .file(path.resolve(__dirname, 'mock', 'sample.json'))
         .pipe($props.plugins.transform('web'))
         .pipe($props.plugins.getResult((result) => {
-          assert(_.has(JSON.parse(result), 'props'))
+          assert(_.has(JSON5.parse(result), 'props'))
           done()
         }))
     })
@@ -215,7 +216,7 @@ describe('$props.plugins', () => {
       gulp.src(path.resolve(__dirname, 'mock', 'sample.json'))
         .pipe($props.plugins.transform('web'))
         .pipe($props.plugins.getResult((result) => {
-          assert(_.has(JSON.parse(result), 'props'))
+          assert(_.has(JSON5.parse(result), 'props'))
           done()
         }))
     })
@@ -223,7 +224,7 @@ describe('$props.plugins', () => {
       gulp.src(path.resolve(__dirname, 'mock', 'sample.yml'))
         .pipe($props.plugins.transform('web'))
         .pipe($props.plugins.getResult((result) => {
-          assert(_.has(JSON.parse(result), 'props'))
+          assert(_.has(JSON5.parse(result), 'props'))
           done()
         }))
     })
@@ -231,7 +232,7 @@ describe('$props.plugins', () => {
       gulp.src(path.resolve(__dirname, 'mock', 'sample.yaml'))
         .pipe($props.plugins.transform('web'))
         .pipe($props.plugins.getResult((result) => {
-          assert(_.has(JSON.parse(result), 'props'))
+          assert(_.has(JSON5.parse(result), 'props'))
           done()
         }))
     })
@@ -244,7 +245,7 @@ describe('$props.plugins', () => {
           }
         }))
         .pipe($props.plugins.getResult((result) => {
-          assert.strictEqual(JSON.parse(result).props.spacing_xx_small.label, 'xx_small')
+          assert.strictEqual(JSON5.parse(result).props.spacing_xx_small.label, 'xx_small')
           done()
         }))
     })
@@ -292,7 +293,7 @@ describe('$props.plugins', () => {
         .on('finish', () => {
           assert.strictEqual(error instanceof Error, false)
           assert.doesNotThrow(() => {
-            JSON.parse(postResult)
+            JSON5.parse(postResult)
           })
           done()
         })
@@ -316,7 +317,7 @@ describe('$props.plugins', () => {
         .pipe($props.plugins.transform('web'))
         .pipe($props.plugins.format('raw.json', { propsFilter: function (prop) { return prop.name === 'account' } }))
         .pipe($props.plugins.getResult(function (result) {
-          postResult = JSON.parse(result)
+          postResult = JSON5.parse(result)
         }))
     })
     it('maps props before formatting', (done) => {
@@ -339,7 +340,7 @@ describe('$props.plugins', () => {
           }
         }))
         .pipe($props.plugins.getResult(function (result) {
-          postResult = JSON.parse(result)
+          postResult = JSON5.parse(result)
         }))
     })
     it('renames the file correctly', (done) => {
@@ -371,7 +372,7 @@ describe('$props.plugins', () => {
           assert.strictEqual(typeof error, 'undefined')
           assert(spy.calledOnce)
           assert.doesNotThrow(() => {
-            JSON.parse(spy.getCall(0).args[0])
+            JSON5.parse(spy.getCall(0).args[0])
           })
           done()
         })
@@ -389,7 +390,7 @@ describe('$props.plugins', () => {
           assert.strictEqual(typeof error, 'undefined')
           assert(spy.calledOnce)
           assert.doesNotThrow(() => {
-            JSON.parse(spy.getCall(0).args[0])
+            JSON5.parse(spy.getCall(0).args[0])
           })
           done()
         })
@@ -553,7 +554,7 @@ describe('$props:formats', () => {
   }
 
   function $toJSON (done) {
-    result = JSON.parse(result)
+    result = JSON5.parse(result)
     done()
   }
 

--- a/test/props/prop-set.js
+++ b/test/props/prop-set.js
@@ -21,6 +21,7 @@ const gulp = require('gulp')
 const gutil = require('gulp-util')
 const through = require('through2')
 const _ = require('lodash')
+const JSON5 = require('json5')
 
 const PropSet = require('../../dist/props/prop-set')
 
@@ -38,7 +39,7 @@ describe('PropSet', () => {
   beforeEach(() => {
     const p = path.resolve(__dirname, 'mock', 'c.json')
     const f = fs.readFileSync(p)
-    def = JSON.parse(f)
+    def = JSON5.parse(f)
     file = new gutil.File({
       path: p,
       contents: new Buffer(f)
@@ -124,7 +125,7 @@ describe('PropSet', () => {
       }
       const defFile = new gutil.File({
         path: 'test.json',
-        contents: new Buffer(JSON.stringify(def))
+        contents: new Buffer(JSON5.stringify(def))
       })
       set = new PropSet(defFile, [], { resolveAliases: false })
       assert.strictEqual(set.def.props.a.value, '{!sky}')
@@ -143,7 +144,7 @@ describe('PropSet', () => {
       }
       const defFile = new gutil.File({
         path: 'test.json',
-        contents: new Buffer(JSON.stringify(def))
+        contents: new Buffer(JSON5.stringify(def))
       })
       set = new PropSet(defFile, [], { includeRawValue: true })
       assert.strictEqual(set.def.props.a.value, 'blue')
@@ -365,11 +366,11 @@ describe('PropSet', () => {
     it('returns valid JSON', () => {
       const json = set.toJSON()
       assert.doesNotThrow(() => {
-        JSON.parse(json)
+        JSON5.parse(json)
       })
     })
     it('adds a "propKeys" array', () => {
-      const def = JSON.parse(set.toJSON())
+      const def = JSON5.parse(set.toJSON())
       assert(_.has(def, 'propKeys'))
       assert(_.isArray(def.propKeys))
       assert.strictEqual(def.propKeys.length, _.keys(def.props).length)

--- a/test/stream-util/index.js
+++ b/test/stream-util/index.js
@@ -17,6 +17,7 @@ var sinon = require('sinon')
 var path = require('path')
 var gulp = require('gulp')
 var through = require('through2')
+let JSON5 = require('json5')
 
 var $stream = require('../../dist/stream-util')
 
@@ -144,7 +145,7 @@ describe('$stream', function () {
           assert(files.length === 1)
           assert(files[0].relative === 'list.json')
           assert.doesNotThrow(function () {
-            JSON.parse(files[0].contents.toString())
+            JSON5.parse(files[0].contents.toString())
           })
           done()
         })
@@ -154,7 +155,7 @@ describe('$stream', function () {
         .pipe($stream.list())
         .pipe(collectFiles())
         .on('finish', function () {
-          var json = JSON.parse(files[0].contents.toString())
+          var json = JSON5.parse(files[0].contents.toString())
           assert(typeof json.items !== 'undefined')
           assert(Array.isArray(json.items))
           assert(json.items.indexOf('a') === 0)
@@ -176,7 +177,7 @@ describe('$stream', function () {
         .pipe($stream.list({ includeExtension: true }))
         .pipe(collectFiles())
         .on('finish', function () {
-          var json = JSON.parse(files[0].contents.toString())
+          var json = JSON5.parse(files[0].contents.toString())
           assert(json.items.indexOf('a.json') === 0)
           assert(json.items.indexOf('b.json') === 1)
           done()
@@ -256,10 +257,10 @@ describe('$stream', function () {
           done()
         })
     })
-    it('pipes an error if invalid JSON is encoutered', function (done) {
+    it('pipes an error if invalid JSON5 file is encoutered', function (done) {
       gulp.src(mockPath('a.json'))
         .pipe(through.obj(function (file, enc, next) {
-          file.contents = new Buffer('{"b":true,}')
+          file.contents = new Buffer('{"b":true,#}')
           next(null, file)
         }))
         .pipe($stream.parseJSON())


### PR DESCRIPTION
JSON5 allows for comments in JSON as well as trailing commas, which is very useful when documenting tokens.