### PR TITLE
Restore built version using Babel

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 /*
 /*/
-!/lib/
+!/dist/
 !README.md
 !package.json
 !RELEASENOTES.md

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
     "Android",
     "aura"
   ],
-  "main": "lib/props/index.js",
+  "main": "dist/props/index.js",
   "scripts": {
-    "test": "jest",
-    "lint": "eslint . --ext .js --format codeframe"
+    "build": "rm -rf dist && babel lib --out-dir dist --presets=es2015",
+    "lint": "eslint . --ext .js --format codeframe",
+    "prepublish": "npm run build",
+    "pretest": "npm run build",
+    "test": "jest"
   },
   "engines": {
     "node": ">=6.3.1"
@@ -48,6 +51,8 @@
     "xml2js": "^0.4.17"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-preset-es2015": "^6.18.0",
     "eslint": "^3.12.2",
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.4.0",


### PR DESCRIPTION
This fixes an issue where using Theo on the front-end with WebPack
and UglifyJS would throw an error (as UglifyJS doesn't support ES6).

@aputinski I'm on the fence about this. The use case is super small and… the only reason I did this is  to allow the usage of `kebabCase` in the Design System's front-end.

### Alternatives

#### 1. Write the function in ES5

We could simply write the kebabCase file in es5 instead of es6.

Pro: cheap fix

Cons:

- it doesn't eliminate the issue that this stays an undocumented feature because we don't have any tests for a browser-specific version of Theo
- inconsistencies:
  - the rest of the module is in ES6
  - the rest of the module is node-only, and only this part becomes browser-friendly

#### 2. Create a separate `kebab-case` package

Pros:
- Gives all of our tooling to access to the same kebabCase function
- it works universally across browser / node
- separation of concerns

Cons:
- we have to care about versioning
- extra dependency management

#### 3. Wait

UglifyJS should become better at handling ES6 in version 3.

Pros: we don't do anything
Cons: we have to minify using another technique until this is fixed