### PR TITLE
fixed error message in “register.js”

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -147,7 +147,7 @@ glob
         registerFormat(name, fs.readFileSync(file, 'utf8'))
         break
       default:
-        throw new Error(`Unrecognized format "${name}.${ext}"`)
+        throw new Error(`Unrecognized format "${name}${ext}"`)
     }
   })
 


### PR DESCRIPTION
The "." dot is already included in the value of ${ext}