### PR TITLE
[FIX] Update npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,9 @@
 !/lib/
 /lib/__tests__
 /lib/__fixtures__
+!/bin/theo.js
+!/bin/scripts
+!CLI.md
 !README.md
 !package.json
 !CHANGELOG.md


### PR DESCRIPTION
As reported here: https://github.com/salesforce-ux/theo/pull/114#issuecomment-323154368

It seemed that beta3 brakes during installation as we didn't updated `.npmignore` before release to include the needed files. This should fix it.

I've seen you included the `readme.md` when publishing, so I've also added the `cli.md`