### PR TITLE
Improve indentation and spacing of formatted tokens

### DIFF
--- a/bin/__tests__/__snapshots__/theo.spec.js.snap
+++ b/bin/__tests__/__snapshots__/theo.spec.js.snap
@@ -2,16 +2,14 @@
 
 exports[`should pass through transform (--transform) 1`] = `
 "
-  
-  $token-a: rgb(255, 0, 0);
+$token-a: rgb(255, 0, 0);
 
 "
 `;
 
 exports[`should print the result if no --dest is passed 1`] = `
 "
-  
-  $token-a: red;
+$token-a: red;
 
 "
 `;

--- a/lib/__tests__/__snapshots__/formats.js.snap
+++ b/lib/__tests__/__snapshots__/formats.js.snap
@@ -35,29 +35,22 @@ exports[`aura.tokens 1`] = `
 exports[`common.js 1`] = `
 "
 module.exports = {
-    
-    tokenColor: \\"#bada55\\",
-    
-    tokenSize: \\"20px\\",
-    
-    tokenString: \\"/assets/images\\",
-    // This should not get escaped in the output
-    tokenQuotes: \\"'Salesforce Sans', \\\\\\"Helvetica Neue\\\\\\", sans-serif\\",
+  tokenColor: \\"#bada55\\",
+  tokenSize: \\"20px\\",
+  tokenString: \\"/assets/images\\",
+  // This should not get escaped in the output
+  tokenQuotes: \\"'Salesforce Sans', \\\\\\"Helvetica Neue\\\\\\", sans-serif\\",
 };
 "
 `;
 
 exports[`cssmodules.css 1`] = `
 "
-  
-  @value token-color: #bada55;
-  
-  @value token-size: 20px;
-  
-  @value token-string: \\"/assets/images\\";
-  /* This should not get escaped in the output */
-  @value token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
-
+@value token-color: #bada55;
+@value token-size: 20px;
+@value token-string: \\"/assets/images\\";
+/* This should not get escaped in the output */
+@value token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
 "
 `;
 
@@ -337,28 +330,22 @@ exports[`json 1`] = `
 
 exports[`less 1`] = `
 "
-  
-  @token-color: #bada55;
-  
-  @token-size: 20px;
-  
-  @token-string: \\"/assets/images\\";
-  // This should not get escaped in the output
-  @token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
+@token-color: #bada55;
+@token-size: 20px;
+@token-string: \\"/assets/images\\";
+// This should not get escaped in the output
+@token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
 "
 `;
 
 exports[`list.scss 1`] = `
 "
 $fixture-list: (
-    
-    \\"token-color\\",
-    
-    \\"token-size\\",
-    
-    \\"token-string\\",
-    // This should not get escaped in the output
-    \\"token-quotes\\",
+  \\"token-color\\",
+  \\"token-size\\",
+  \\"token-string\\",
+  // This should not get escaped in the output
+  \\"token-quotes\\",
 );
 "
 `;
@@ -366,14 +353,11 @@ $fixture-list: (
 exports[`map.scss 1`] = `
 "
 $fixture-map: (
-    
-    'token-color': (#bada55),
-    
-    'token-size': (20px),
-    
-    'token-string': (\\"/assets/images\\"),
-    // This should not get escaped in the output
-    'token-quotes': ('Salesforce Sans', \\"Helvetica Neue\\", sans-serif),
+  'token-color': (#bada55),
+  'token-size': (20px),
+  'token-string': (\\"/assets/images\\"),
+  // This should not get escaped in the output
+  'token-quotes': ('Salesforce Sans', \\"Helvetica Neue\\", sans-serif),
 );
 "
 `;
@@ -381,14 +365,11 @@ $fixture-map: (
 exports[`map.variables.scss 1`] = `
 "
 $fixture-map: (
-    
-    'token-color': $token-color,
-    
-    'token-size': $token-size,
-    
-    'token-string': $token-string,
-    // This should not get escaped in the output
-    'token-quotes': $token-quotes,
+  'token-color': $token-color,
+  'token-size': $token-size,
+  'token-string': $token-string,
+  // This should not get escaped in the output
+  'token-quotes': $token-quotes,
 );
 "
 `;
@@ -432,39 +413,30 @@ exports[`raw.json 1`] = `
 
 exports[`sass 1`] = `
 "
-  
-  $token-color: #bada55
-  
-  $token-size: 20px
-  
-  $token-string: \\"/assets/images\\"
-  // This should not get escaped in the output
-  $token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif
+$token-color: #bada55
+$token-size: 20px
+$token-string: \\"/assets/images\\"
+// This should not get escaped in the output
+$token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif
 "
 `;
 
 exports[`scss 1`] = `
 "
-  
-  $token-color: #bada55;
-  
-  $token-size: 20px;
-  
-  $token-string: \\"/assets/images\\";
-  // This should not get escaped in the output
-  $token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
+$token-color: #bada55;
+$token-size: 20px;
+$token-string: \\"/assets/images\\";
+// This should not get escaped in the output
+$token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
 "
 `;
 
 exports[`styl 1`] = `
 "
-  
-  token-color: #bada55
-  
-  token-size: 20px
-  
-  token-string: \\"/assets/images\\"
-  // This should not get escaped in the output
-  token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif
+token-color: #bada55
+token-size: 20px
+token-string: \\"/assets/images\\"
+// This should not get escaped in the output
+token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif
 "
 `;

--- a/lib/formats/common.js.hbs
+++ b/lib/formats/common.js.hbs
@@ -2,8 +2,10 @@
 {{! Licensed under BSD 3-Clause - https://opensource.org/licenses/BSD-3-Clause }}
 
 module.exports = {
-  {{#each props as |prop|}}
-    {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
-    {{camelcase prop.name}}: "{{{replace prop.value '"' '\"'}}}",
-  {{/each}}
+{{#each props as |prop|}}
+  {{#if prop.comment}}
+  // {{{prop.comment}}}
+  {{/if}}
+  {{ camelcase prop.name}}: "{{{replace prop.value '"' '\"'}}}",
+{{/each}}
 };

--- a/lib/formats/cssmodules.css.hbs
+++ b/lib/formats/cssmodules.css.hbs
@@ -2,7 +2,8 @@
 {{! Licensed under BSD 3-Clause - https://opensource.org/licenses/BSD-3-Clause }}
 
 {{#each props as |prop|}}
-  {{#if prop.comment}}/* {{{prop.comment}}} */{{/if}}
+  {{#if prop.comment~}}
+  /* {{{prop.comment}}} */
+  {{/if~}}
   @value {{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}
-

--- a/lib/formats/less.hbs
+++ b/lib/formats/less.hbs
@@ -2,6 +2,8 @@
 {{! Licensed under BSD 3-Clause - https://opensource.org/licenses/BSD-3-Clause }}
 
 {{#each props as |prop|}}
-  {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
+  {{#if prop.comment~}}
+    // {{{prop.comment}}}
+  {{/if~}}
   @{{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/list.scss.hbs
+++ b/lib/formats/list.scss.hbs
@@ -2,8 +2,10 @@
 {{! Licensed under BSD 3-Clause - https://opensource.org/licenses/BSD-3-Clause }}
 
 ${{stem meta.file}}-list: (
-  {{#each props as |prop|}}
-    {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
-    "{{kebabcase prop.name}}",
-  {{/each}}
+{{#each props as |prop|}}
+  {{#if prop.comment}}
+  // {{{prop.comment}}}
+  {{/if}}
+  "{{kebabcase prop.name}}",
+{{/each}}
 );

--- a/lib/formats/map.scss.hbs
+++ b/lib/formats/map.scss.hbs
@@ -8,8 +8,10 @@
   See issue here: http://www.sassmeister.com/gist/705e0d611be460d7bed020283ea1ffd2
 }}
 ${{stem meta.file}}-map: (
-  {{#each props as |prop|}}
-    {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
-    '{{kebabcase prop.name}}': ({{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}),
-  {{/each}}
+{{#each props as |prop|}}
+  {{#if prop.comment}}
+  // {{{prop.comment}}}
+  {{/if}}
+  '{{kebabcase prop.name}}': ({{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}),
+{{/each}}
 );

--- a/lib/formats/map.variables.scss.hbs
+++ b/lib/formats/map.variables.scss.hbs
@@ -2,8 +2,10 @@
 {{! Licensed under BSD 3-Clause - https://opensource.org/licenses/BSD-3-Clause }}
 
 ${{stem meta.file}}-map: (
-  {{#each props as |prop|}}
-    {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
-    '{{kebabcase prop.name}}': ${{kebabcase prop.name}},
-  {{/each}}
+{{#each props as |prop|}}
+  {{#if prop.comment}}
+  // {{{prop.comment}}}
+  {{/if}}
+  '{{kebabcase prop.name}}': ${{kebabcase prop.name}},
+{{/each}}
 );

--- a/lib/formats/sass.hbs
+++ b/lib/formats/sass.hbs
@@ -2,6 +2,8 @@
 {{! Licensed under BSD 3-Clause - https://opensource.org/licenses/BSD-3-Clause }}
 
 {{#each props as |prop|}}
-  {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
+  {{#if prop.comment~}}
+    // {{{prop.comment}}}
+  {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}
 {{/each}}

--- a/lib/formats/scss.hbs
+++ b/lib/formats/scss.hbs
@@ -2,6 +2,8 @@
 {{! Licensed under BSD 3-Clause - https://opensource.org/licenses/BSD-3-Clause }}
 
 {{#each props as |prop|}}
-  {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
+  {{#if prop.comment~}}
+    // {{{prop.comment}}}
+  {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/styl.hbs
+++ b/lib/formats/styl.hbs
@@ -2,6 +2,8 @@
 {{! Licensed under BSD 3-Clause - https://opensource.org/licenses/BSD-3-Clause }}
 
 {{#each props as |prop|}}
-  {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
+  {{#if prop.comment~}}
+    // {{{prop.comment}}}
+  {{/if~}}
   {{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}
 {{/each}}


### PR DESCRIPTION
Was having the same spacing/indentation issue mentioned in #118, this should fix it.

Downside is you lose perfect indentation within the handlebars templates but worth it for perfect output in my opinion.

_Previous:_
```sass
  // comment
  $token-one: red;

  $token-two: green;
  // comment
  $token-three: blue;
```

_Update:_
```sass
// comment
$token-one: red;
$token-two: green;
// comment
$token-three: blue;
```

Should resolve all formats that are using `.hbs` templates: `common.js`, `less`, `list.scss`, `map.scss`, `map.variables.scss`, `modules.css`, `sass`, `scss`, and `styl`.