### PR TITLE
Fix stylus format

### DIFF
--- a/lib/__tests__/__snapshots__/formats.js.snap
+++ b/lib/__tests__/__snapshots__/formats.js.snap
@@ -433,10 +433,10 @@ $token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
 
 exports[`styl 1`] = `
 "
-token-color: #bada55
-token-size: 20px
-token-string: \\"/assets/images\\"
+$token-color = #bada55
+$token-size = 20px
+$token-string = \\"/assets/images\\"
 // This should not get escaped in the output
-token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif
+$token-quotes = 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif
 "
 `;

--- a/lib/formats/styl.hbs
+++ b/lib/formats/styl.hbs
@@ -5,5 +5,5 @@
   {{#if prop.comment~}}
     // {{{prop.comment}}}
   {{/if~}}
-  {{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}
+  ${{kebabcase prop.name}} = {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}
 {{/each}}


### PR DESCRIPTION
As stylus is white-space sensitive the indentation led to an error.
Also the assignment operator needs to be `=`.

We should also use the opportunity of the stylus format not being used widely yet (at least that is what I assume, as the error would have come up earlier) to add the leading `$` to variables. This is not necessary, but considered best practice – for details see https://gist.github.com/declandewet/7220997#variable-naming