### PR TITLE
Fix misspelled `font-families` category, add in kebab case reference

### DIFF
--- a/lib/formats/html.js
+++ b/lib/formats/html.js
@@ -4,6 +4,7 @@
 let groupBy = require("lodash/groupBy");
 let camelCase = require("lodash/camelCase");
 let upperfirst = require("lodash/upperFirst");
+let kebabCase = require("lodash/kebabCase");
 
 class Styleguide {
   constructor(json) {
@@ -24,11 +25,11 @@ class Styleguide {
   }
 
   renderRow(prop, example) {
-    let name = camelCase(prop.name);
+    let name = kebabCase(prop.name);
     return `
       <tr>
         <th scope="row">
-          <code>${name}</code>
+          <code>$${name}</code>
         </th>
         <td>
           <code>${prop.value}</code>
@@ -407,7 +408,7 @@ class Styleguide {
               ${this.renderSection("font-weight", "Font Weights")}
               ${this.renderSection("font-size", "Font Sizes")}
               ${this.renderSection("line-height", "Line Heights")}
-              ${this.renderSection("font-families", "Font Families")}
+              ${this.renderSection("font-family", "Font Families")}
               ${this.renderSection("border-style", "Border Styles")}
               ${this.renderSection("border-color", "Border Colors")}
               ${this.renderSection("radius", "Radius")}

--- a/lib/formats/html.js
+++ b/lib/formats/html.js
@@ -4,7 +4,7 @@
 let groupBy = require("lodash/groupBy");
 let camelCase = require("lodash/camelCase");
 let upperfirst = require("lodash/upperFirst");
-let kebabCase = require("lodash/kebabCase");
+//let kebabCase = require("lodash/kebabCase");
 
 class Styleguide {
   constructor(json) {

--- a/lib/formats/html.js
+++ b/lib/formats/html.js
@@ -4,7 +4,6 @@
 let groupBy = require("lodash/groupBy");
 let camelCase = require("lodash/camelCase");
 let upperfirst = require("lodash/upperFirst");
-//let kebabCase = require("lodash/kebabCase");
 
 class Styleguide {
   constructor(json) {

--- a/lib/formats/html.js
+++ b/lib/formats/html.js
@@ -25,11 +25,11 @@ class Styleguide {
   }
 
   renderRow(prop, example) {
-    let name = kebabCase(prop.name);
+    let name = camelCase(prop.name);
     return `
       <tr>
         <th scope="row">
-          <code>$${name}</code>
+          <code>${name}</code>
         </th>
         <td>
           <code>${prop.value}</code>


### PR DESCRIPTION
This fixes a spelling error that prevents adding `font-family` as a section. It also adds in a reference for kebab case but doesn't address being able to set the case formatting in your gulp or main js file.