### PR TITLE
Do not render multiple box-shadow sections

### DIFF
--- a/lib/__tests__/__snapshots__/formats.js.snap
+++ b/lib/__tests__/__snapshots__/formats.js.snap
@@ -285,7 +285,6 @@ exports[`html 1`] = `
               
               
               
-              
             </main>
           </div>
         </body>

--- a/lib/formats/html.js
+++ b/lib/formats/html.js
@@ -442,7 +442,6 @@ class Styleguide {
                 "Inner Drop Shadows",
                 this.renderDropShadow
               )}
-              ${this.renderSection("box-shadow", "Box Shadows")}
               ${this.renderSection("text-color", "Text Colors")}
               ${this.renderSection("text-shadow", "Text Shadows")}
               ${this.renderSection("time", "Time")}


### PR DESCRIPTION
When using  the format ` type: 'html'` with a box-shadow token, two box-shadow sections are rendered. This pull request removes the duplicate render call and removes the extra blank space from test snapshot