### PR TITLE
Update default transforms table

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Transforms are a named group of value transforms. Theo ships with several predef
 |-- | ---
 | `raw` | `[]`
 | `web` | `['color/rgb']`
-| `ios` | `['color/hex8argb', 'relative/pixelValue', 'percentage/float']`
+| `ios` | `['color/rgb', 'relative/pixelValue', 'percentage/float']`
 | `android` | `['color/hex8argb', 'relative/pixelValue', 'percentage/float']`
 
 ### Value Transforms


### PR DESCRIPTION
Just spotted that the new default transforms table in the README had the wrong transform for `ios` listed for color.