### PR TITLE
Fix multiline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ theo.registerFormat(
   // Source: {{stem meta.file}}
   module.exports = [
     {{#each props as |prop|}}
-      {{#if prop.comment}}// {{{prop.comment}}}{{/if}}
+      {{#if prop.comment}}{{{commoncomment prop.comment}}}{{/if}}
       ['{{camelcase prop.name}}', '{{prop.value}}'],
     {{/each}}
   ]

--- a/lib/__tests__/__snapshots__/formats.js.snap
+++ b/lib/__tests__/__snapshots__/formats.js.snap
@@ -46,6 +46,20 @@ exports[`common.js 1`] = `
 };"
 `;
 
+exports[`common.js with multiline comments 1`] = `
+"module.exports = {
+  tokenColor: \\"#bada55\\",
+  tokenSize: \\"20px\\",
+  tokenString: \\"/assets/images\\",
+  tokenNumber: 2,
+  /*
+    Multiline
+    Comment
+  */
+  tokenQuotes: \\"'Salesforce Sans', \\\\\\"Helvetica Neue\\\\\\", sans-serif\\",
+};"
+`;
+
 exports[`cssmodules.css 1`] = `
 "
 @value token-color: #bada55;

--- a/lib/__tests__/__snapshots__/formats.js.snap
+++ b/lib/__tests__/__snapshots__/formats.js.snap
@@ -41,7 +41,7 @@ exports[`common.js 1`] = `
   tokenSize: \\"20px\\",
   tokenString: \\"/assets/images\\",
   tokenNumber: 2,
-  // This should not get escaped in the output
+  /* This should not get escaped in the output */
   tokenQuotes: \\"'Salesforce Sans', \\\\\\"Helvetica Neue\\\\\\", sans-serif\\",
 };"
 `;
@@ -90,7 +90,7 @@ $token-color: #bada55 !default
 $token-size: 20px !default
 $token-string: \\"/assets/images\\" !default
 $token-number: 2 !default
-// This should not get escaped in the output
+/* This should not get escaped in the output */
 $token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif !default
 "
 `;
@@ -101,7 +101,7 @@ $token-color: #bada55 !default;
 $token-size: 20px !default;
 $token-string: \\"/assets/images\\" !default;
 $token-number: 2 !default;
-// This should not get escaped in the output
+/* This should not get escaped in the output */
 $token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif !default;
 "
 `;
@@ -366,7 +366,7 @@ exports[`less 1`] = `
 @token-size: 20px;
 @token-string: \\"/assets/images\\";
 @token-number: 2;
-// This should not get escaped in the output
+/* This should not get escaped in the output */
 @token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
 "
 `;
@@ -378,7 +378,7 @@ $fixture-list: (
   \\"token-size\\",
   \\"token-string\\",
   \\"token-number\\",
-  // This should not get escaped in the output
+  /* This should not get escaped in the output */
   \\"token-quotes\\",
 );
 "
@@ -391,7 +391,7 @@ $fixture-map: (
   'token-size': (20px),
   'token-string': (\\"/assets/images\\"),
   'token-number': (2),
-  // This should not get escaped in the output
+  /* This should not get escaped in the output */
   'token-quotes': ('Salesforce Sans', \\"Helvetica Neue\\", sans-serif),
 );
 "
@@ -404,7 +404,7 @@ $fixture-map: (
   'token-size': $token-size,
   'token-string': $token-string,
   'token-number': $token-number,
-  // This should not get escaped in the output
+  /* This should not get escaped in the output */
   'token-quotes': $token-quotes,
 );
 "
@@ -415,7 +415,7 @@ exports[`module.js 1`] = `
 export const tokenSize = \\"20px\\";
 export const tokenString = \\"/assets/images\\";
 export const tokenNumber = 2;
-// This should not get escaped in the output
+/* This should not get escaped in the output */
 export const tokenQuotes = \\"'Salesforce Sans', \\\\\\"Helvetica Neue\\\\\\", sans-serif\\";"
 `;
 
@@ -469,7 +469,7 @@ $token-color: #bada55
 $token-size: 20px
 $token-string: \\"/assets/images\\"
 $token-number: 2
-// This should not get escaped in the output
+/* This should not get escaped in the output */
 $token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif
 "
 `;
@@ -480,7 +480,7 @@ $token-color: #bada55;
 $token-size: 20px;
 $token-string: \\"/assets/images\\";
 $token-number: 2;
-// This should not get escaped in the output
+/* This should not get escaped in the output */
 $token-quotes: 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif;
 "
 `;
@@ -491,7 +491,7 @@ $token-color = #bada55
 $token-size = 20px
 $token-string = \\"/assets/images\\"
 $token-number = 2
-// This should not get escaped in the output
+/* This should not get escaped in the output */
 $token-quotes = 'Salesforce Sans', \\"Helvetica Neue\\", sans-serif
 "
 `;

--- a/lib/__tests__/formats.js
+++ b/lib/__tests__/formats.js
@@ -103,6 +103,19 @@ it("common.js", () => {
   expect(format("common.js")).toMatchSnapshot();
 });
 
+it("common.js with multiline comments", () => {
+  const result = format(
+    "common.js",
+    `
+    props:
+      TOKEN_QUOTES:
+        comment: |
+          Multiline
+          Comment`
+  );
+  expect(result).toMatchSnapshot();
+});
+
 it("html", () => {
   expect(format("html")).toMatchSnapshot();
 });

--- a/lib/__tests__/util.js
+++ b/lib/__tests__/util.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present, salesforce.com, inc. All rights reserved
+// Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license
+
+/* eslint-env jest */
+
+const { cStyleComment, commonComment, indent } = require("../util");
+
+const comment = `
+lines
+of
+comments
+`.slice(1);
+
+const result = `
+/*
+  lines
+  of
+  comments
+*/`.slice(1);
+
+describe("commonComment", () => {
+  it("prepends // to a single line", () => {
+    const res = commonComment("One line of a comment");
+    expect(res).toEqual("// One line of a comment");
+  });
+
+  it("wraps multiple lines with /* ... */", () => {
+    const res = commonComment(comment.trim());
+    expect(res).toEqual(result);
+  });
+});
+
+describe("cStyleComment", () => {
+  it("wraps single line with /* ... */", () => {
+    const res = cStyleComment("One line of a comment");
+    expect(res).toEqual("/* One line of a comment */");
+  });
+
+  it("wraps multiple lines with /* ... */", () => {
+    const res = cStyleComment(comment.trim());
+    expect(res).toEqual(result);
+  });
+});
+
+describe("indent", () => {
+  it("default indentation level", () => {
+    expect(indent("a\nb")).toEqual("  a\n  b");
+  });
+
+  it("custom indentation level", () => {
+    expect(indent("a\nb", 1)).toEqual(" a\n b");
+  });
+});

--- a/lib/__tests__/util.js
+++ b/lib/__tests__/util.js
@@ -3,42 +3,32 @@
 
 /* eslint-env jest */
 
-const { cStyleComment, commonComment, indent } = require("../util");
+const { comment, indent } = require("../util");
 
-const comment = `
+const input = `
 lines
 of
 comments
-`.slice(1);
+`
+  .slice(1)
+  .trim();
 
-const result = `
+const output = `
 /*
   lines
   of
   comments
 */`.slice(1);
 
-describe("commonComment", () => {
-  it("prepends // to a single line", () => {
-    const res = commonComment("One line of a comment");
-    expect(res).toEqual("// One line of a comment");
-  });
-
-  it("wraps multiple lines with /* ... */", () => {
-    const res = commonComment(comment.trim());
-    expect(res).toEqual(result);
-  });
-});
-
-describe("cStyleComment", () => {
+describe("comment", () => {
   it("wraps single line with /* ... */", () => {
-    const res = cStyleComment("One line of a comment");
+    const res = comment("One line of a comment");
     expect(res).toEqual("/* One line of a comment */");
   });
 
   it("wraps multiple lines with /* ... */", () => {
-    const res = cStyleComment(comment.trim());
-    expect(res).toEqual(result);
+    const res = comment(input);
+    expect(res).toEqual(output);
   });
 });
 

--- a/lib/formats/common.js.js
+++ b/lib/formats/common.js.js
@@ -3,6 +3,7 @@
 
 const Immutable = require("immutable");
 const _ = require("lodash");
+const { commonComment, indent } = require("../util");
 
 module.exports = def => {
   const content = def
@@ -10,7 +11,9 @@ module.exports = def => {
     .map(prop => {
       let result = Immutable.List();
       if (prop.has("comment")) {
-        result = result.push(`  // ${prop.get("comment")}`);
+        result = result.push(
+          `${indent(commonComment(prop.get("comment").trim()))}`
+        );
       }
       const k = _.camelCase(prop.get("name"));
       const v = JSON.stringify(prop.get("value"));

--- a/lib/formats/common.js.js
+++ b/lib/formats/common.js.js
@@ -3,7 +3,7 @@
 
 const Immutable = require("immutable");
 const _ = require("lodash");
-const { commonComment, indent } = require("../util");
+const { comment, indent } = require("../util");
 
 module.exports = def => {
   const content = def
@@ -11,9 +11,7 @@ module.exports = def => {
     .map(prop => {
       let result = Immutable.List();
       if (prop.has("comment")) {
-        result = result.push(
-          `${indent(commonComment(prop.get("comment").trim()))}`
-        );
+        result = result.push(`${indent(comment(prop.get("comment").trim()))}`);
       }
       const k = _.camelCase(prop.get("name"));
       const v = JSON.stringify(prop.get("value"));

--- a/lib/formats/cssmodules.css.hbs
+++ b/lib/formats/cssmodules.css.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-  /* {{{prop.comment}}} */
+  {{{trimLeft (indent (cstylecomment (trim prop.comment)))}}}
   {{/if~}}
   @value {{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/cssmodules.css.hbs
+++ b/lib/formats/cssmodules.css.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-  {{{trimLeft (indent (cstylecomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if~}}
   @value {{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/custom-properties.css.hbs
+++ b/lib/formats/custom-properties.css.hbs
@@ -4,7 +4,7 @@
 :root {
 {{#each props as |prop|}}
   {{#if prop.comment}}
-  {{{trimLeft (indent (cstylecomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if}}
   --{{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/custom-properties.css.hbs
+++ b/lib/formats/custom-properties.css.hbs
@@ -4,7 +4,7 @@
 :root {
 {{#each props as |prop|}}
   {{#if prop.comment}}
-  /* {{{prop.comment}}} */
+  {{{trimLeft (indent (cstylecomment (trim prop.comment)))}}}
   {{/if}}
   --{{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/default.sass.hbs
+++ b/lib/formats/default.sass.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}} !default
 {{/each}}

--- a/lib/formats/default.sass.hbs
+++ b/lib/formats/default.sass.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-    // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}} !default
 {{/each}}

--- a/lib/formats/default.scss.hbs
+++ b/lib/formats/default.scss.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}} !default;
 {{/each}}

--- a/lib/formats/default.scss.hbs
+++ b/lib/formats/default.scss.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-    // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}} !default;
 {{/each}}

--- a/lib/formats/less.hbs
+++ b/lib/formats/less.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if~}}
   @{{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/less.hbs
+++ b/lib/formats/less.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-    // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if~}}
   @{{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/list.scss.hbs
+++ b/lib/formats/list.scss.hbs
@@ -4,7 +4,7 @@
 ${{stem meta.file}}-list: (
 {{#each props as |prop|}}
   {{#if prop.comment}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if}}
   "{{kebabcase prop.name}}",
 {{/each}}

--- a/lib/formats/list.scss.hbs
+++ b/lib/formats/list.scss.hbs
@@ -4,7 +4,7 @@
 ${{stem meta.file}}-list: (
 {{#each props as |prop|}}
   {{#if prop.comment}}
-  // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if}}
   "{{kebabcase prop.name}}",
 {{/each}}

--- a/lib/formats/map.scss.hbs
+++ b/lib/formats/map.scss.hbs
@@ -10,7 +10,7 @@
 ${{stem meta.file}}-map: (
 {{#each props as |prop|}}
   {{#if prop.comment}}
-  // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if}}
   '{{kebabcase prop.name}}': ({{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}),
 {{/each}}

--- a/lib/formats/map.scss.hbs
+++ b/lib/formats/map.scss.hbs
@@ -10,7 +10,7 @@
 ${{stem meta.file}}-map: (
 {{#each props as |prop|}}
   {{#if prop.comment}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if}}
   '{{kebabcase prop.name}}': ({{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}),
 {{/each}}

--- a/lib/formats/map.variables.scss.hbs
+++ b/lib/formats/map.variables.scss.hbs
@@ -4,7 +4,7 @@
 ${{stem meta.file}}-map: (
 {{#each props as |prop|}}
   {{#if prop.comment}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if}}
   '{{kebabcase prop.name}}': ${{kebabcase prop.name}},
 {{/each}}

--- a/lib/formats/map.variables.scss.hbs
+++ b/lib/formats/map.variables.scss.hbs
@@ -4,7 +4,7 @@
 ${{stem meta.file}}-map: (
 {{#each props as |prop|}}
   {{#if prop.comment}}
-  // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if}}
   '{{kebabcase prop.name}}': ${{kebabcase prop.name}},
 {{/each}}

--- a/lib/formats/module.js.js
+++ b/lib/formats/module.js.js
@@ -3,6 +3,7 @@
 
 const Immutable = require("immutable");
 const _ = require("lodash");
+const { commonComment } = require("../util");
 
 module.exports = def => {
   return def
@@ -10,7 +11,7 @@ module.exports = def => {
     .map(prop => {
       let result = Immutable.List();
       if (prop.has("comment")) {
-        result = result.push(`// ${prop.get("comment")}`);
+        result = result.push(commonComment(prop.get("comment").trim()));
       }
       const k = _.camelCase(prop.get("name"));
       const v = JSON.stringify(prop.get("value"));

--- a/lib/formats/module.js.js
+++ b/lib/formats/module.js.js
@@ -3,7 +3,7 @@
 
 const Immutable = require("immutable");
 const _ = require("lodash");
-const { commonComment } = require("../util");
+const { comment } = require("../util");
 
 module.exports = def => {
   return def
@@ -11,7 +11,7 @@ module.exports = def => {
     .map(prop => {
       let result = Immutable.List();
       if (prop.has("comment")) {
-        result = result.push(commonComment(prop.get("comment").trim()));
+        result = result.push(comment(prop.get("comment").trim()));
       }
       const k = _.camelCase(prop.get("name"));
       const v = JSON.stringify(prop.get("value"));

--- a/lib/formats/sass.hbs
+++ b/lib/formats/sass.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-    // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}
 {{/each}}

--- a/lib/formats/sass.hbs
+++ b/lib/formats/sass.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}
 {{/each}}

--- a/lib/formats/scss.hbs
+++ b/lib/formats/scss.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/scss.hbs
+++ b/lib/formats/scss.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-    // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}}: {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}};
 {{/each}}

--- a/lib/formats/styl.hbs
+++ b/lib/formats/styl.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
+  {{{trimLeft (indent (comment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}} = {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}
 {{/each}}

--- a/lib/formats/styl.hbs
+++ b/lib/formats/styl.hbs
@@ -3,7 +3,7 @@
 
 {{#each props as |prop|}}
   {{#if prop.comment~}}
-    // {{{prop.comment}}}
+  {{{trimLeft (indent (commoncomment (trim prop.comment)))}}}
   {{/if~}}
   ${{kebabcase prop.name}} = {{#eq prop.type "string"}}"{{/eq}}{{{prop.value}}}{{#eq prop.type "string"}}"{{/eq}}
 {{/each}}

--- a/lib/register.js
+++ b/lib/register.js
@@ -10,7 +10,7 @@ const path = require("path");
 
 const { isString, isFunction } = require("lodash");
 
-const { kebabCase } = require("./util");
+const { kebabCase, cStyleComment, commonComment, indent } = require("./util");
 
 // //////////////////////////////////////////////////////////////////
 // Helpers
@@ -21,6 +21,9 @@ require("handlebars-helpers")({
 });
 
 handlebars.registerHelper("kebabcase", kebabCase);
+handlebars.registerHelper("cstylecomment", cStyleComment);
+handlebars.registerHelper("commoncomment", commonComment);
+handlebars.registerHelper("indent", indent);
 
 // //////////////////////////////////////////////////////////////////
 // Register

--- a/lib/register.js
+++ b/lib/register.js
@@ -10,7 +10,7 @@ const path = require("path");
 
 const { isString, isFunction } = require("lodash");
 
-const { kebabCase, cStyleComment, commonComment, indent } = require("./util");
+const { kebabCase, comment, indent } = require("./util");
 
 // //////////////////////////////////////////////////////////////////
 // Helpers
@@ -21,8 +21,7 @@ require("handlebars-helpers")({
 });
 
 handlebars.registerHelper("kebabcase", kebabCase);
-handlebars.registerHelper("cstylecomment", cStyleComment);
-handlebars.registerHelper("commoncomment", commonComment);
+handlebars.registerHelper("comment", comment);
 handlebars.registerHelper("indent", indent);
 
 // //////////////////////////////////////////////////////////////////

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,14 +6,12 @@ const noCase = require("no-case");
 
 const splitLines = string => string.split(/\r\n|[\r\n\u2028\u2029]/g);
 
-const lineComment = string => `// ${splitLines(string).join(`\n// `)}`;
-
 const indent = (string, size = 2) => {
   const pad = " ".repeat(size);
   return `${pad}${splitLines(string).join(`\n${pad}`)}`;
 };
 
-const cStyleComment = string => {
+const comment = string => {
   const lineCount = splitLines(string).length;
   let comment;
   if (lineCount > 1) {
@@ -22,13 +20,6 @@ const cStyleComment = string => {
     comment = `/* ${string.trim()} */`;
   }
   return comment;
-};
-
-const commonComment = string => {
-  const lineCount = splitLines(string).length;
-  const commented =
-    lineCount === 1 ? lineComment(string.trim()) : cStyleComment(string, 0);
-  return commented;
 };
 
 const allMatches = (s, pattern) => {
@@ -56,6 +47,5 @@ module.exports = {
   remToPx,
   kebabCase,
   indent,
-  commonComment,
-  cStyleComment
+  comment
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,33 @@
 const Immutable = require("immutable-ext");
 const noCase = require("no-case");
 
+const splitLines = string => string.split(/\r\n|[\r\n\u2028\u2029]/g);
+
+const lineComment = string => `// ${splitLines(string).join(`\n// `)}`;
+
+const indent = (string, size = 2) => {
+  const pad = " ".repeat(size);
+  return `${pad}${splitLines(string).join(`\n${pad}`)}`;
+};
+
+const cStyleComment = string => {
+  const lineCount = splitLines(string).length;
+  let comment;
+  if (lineCount > 1) {
+    comment = `/*\n${indent(string)}\n*/`;
+  } else {
+    comment = `/* ${string.trim()} */`;
+  }
+  return comment;
+};
+
+const commonComment = string => {
+  const lineCount = splitLines(string).length;
+  const commented =
+    lineCount === 1 ? lineComment(string.trim()) : cStyleComment(string, 0);
+  return commented;
+};
+
 const allMatches = (s, pattern) => {
   let matches = Immutable.List();
   let match;
@@ -27,5 +54,8 @@ module.exports = {
   allMatches,
   isRelativeSpacing,
   remToPx,
-  kebabCase
+  kebabCase,
+  indent,
+  commonComment,
+  cStyleComment
 };


### PR DESCRIPTION
As mentioned in #139 here is my suggested change to fix handling of multiline comments.

The `commonComment` function determines by line count whether to chose Double-Slashes _`// `_ or C-Style comments _`/* ... */`_

For better consistency I also updated other formats than common.js - An extra commit intended to increase comprehensibility.

A bit of context for the LineBreak Character can be found at the [eslint repo](https://github.com/eslint/eslint/pull/7898/files#diff-6198b73cda8ab9ac49ed872ead7fb268R294)