### PR TITLE
Update README.md to show using an array of props

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,18 @@ or [YAML](http://yaml.org/) and should conform to the following spec:
       }
     }
   },
+  
+  // Optional
+  // Alternatively, you can define props as an array
+  // Useful for maintaining source order in output tokens
+  "props": [
+    {
+      // Required
+      "name": "color_brand",
+      
+      // All other properties same as above
+    }
+  ],
 
   // Optional
   // This object will be merged into each property


### PR DESCRIPTION
### Changes

Add alternative form of `props` as an array, rather than an object, to the spec section of the README.

### Motivation

We recently used theo (thanks for a super helpful tool!) to generate [our tokens](https://mineral-ui.com/tokens). We needed the output tokens to be in the same order as those in source, but was having a difficult time doing this using an object for `props`. We only discovered you could use an array by searching the issues.