### PR TITLE
Use the right Android XML Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,11 @@ let formatOptions = {
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <property name="PROP_NAME" type="PROP_TYPE" category="PROP_CATEGORY">PROP_VALUE</property>
-  <color name="PROP_NAME" type="color" category="PROP_CATEGORY">PROP_VALUE</color>
+  <color name="PROP_NAME" category="PROP_CATEGORY">PROP_VALUE</color>
+  <dimen name="PROP_NAME" category="PROP_CATEGORY">PROP_VALUE</dimen>
+  <string name="PROP_NAME" category="PROP_CATEGORY">PROP_VALUE</string>
+  <integer name="PROP_NAME" category="PROP_CATEGORY">PROP_VALUE</integer>
+  <property name="PROP_NAME" category="PROP_CATEGORY">PROP_VALUE</property>
 </resources>
 ```
 

--- a/lib/__tests__/__snapshots__/formats.js.snap
+++ b/lib/__tests__/__snapshots__/formats.js.snap
@@ -3,10 +3,10 @@
 exports[`android.xml 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <resources>
-  <property name=\\"TOKEN_COLOR\\" category=\\"background-color\\">#bada55</property>
-  <property name=\\"TOKEN_SIZE\\" category=\\"spacing\\">20px</property>
-  <property name=\\"TOKEN_STRING\\" category=\\"test\\">/assets/images</property>
-  <property name=\\"TOKEN_NUMBER\\" category=\\"test\\">2</property>
+  <color name=\\"TOKEN_COLOR\\" category=\\"background-color\\">#bada55</color>
+  <dimen name=\\"TOKEN_SIZE\\" category=\\"spacing\\">20px</dimen>
+  <string name=\\"TOKEN_STRING\\" category=\\"test\\">/assets/images</string>
+  <integer name=\\"TOKEN_NUMBER\\" category=\\"test\\">2</integer>
   <property name=\\"TOKEN_QUOTES\\" category=\\"test\\">&apos;Salesforce Sans&apos;, &quot;Helvetica Neue&quot;, sans-serif</property>
 </resources>"
 `;

--- a/lib/formats/android.xml.js
+++ b/lib/formats/android.xml.js
@@ -10,9 +10,15 @@ module.exports = def => {
       .get("props")
       .map(prop => {
         const key = (() => {
-          switch (prop.type) {
+          switch (prop.get("type")) {
             case "color":
-              return prop.type;
+              return "color";
+            case "size":
+              return "dimen";
+            case "number":
+              return "integer";
+            case "string":
+              return "string";
             default:
               return "property";
           }
@@ -32,6 +38,8 @@ module.exports = def => {
       })
       .toJS()
   };
-
-  return xml(o, { indent: "  ", declaration: true });
+  return xml(o, {
+    indent: "  ",
+    declaration: true
+  });
 };


### PR DESCRIPTION
As documented on [this page](https://developer.android.com/guide/topics/resources/more-resources) Android developers can't use the `property` tag for XML. 

This PR adapts the XML output to use the right tags based on the value type.