### PR TITLE
Output dp values in Android XML

### DIFF
--- a/lib/__tests__/transforms.js
+++ b/lib/__tests__/transforms.js
@@ -151,3 +151,13 @@ describe("relative/pixelValue", () => {
     expect(t(p)).toEqual("5");
   });
 });
+
+describe("absolute/dp", () => {
+  const t = get("absolute/dp");
+  it("converts px to dp", () => {
+    const p = Immutable.fromJS({
+      value: "1px"
+    });
+    expect(t(p)).toEqual("1dp");
+  });
+});

--- a/lib/register.js
+++ b/lib/register.js
@@ -126,6 +126,7 @@ registerTransform("ios", [
 registerTransform("android", [
   "color/hex8argb",
   "relative/pixelValue",
+  "absolute/dp",
   "percentage/float"
 ]);
 

--- a/lib/transforms/unit.js
+++ b/lib/transforms/unit.js
@@ -1,7 +1,12 @@
 // Copyright (c) 2015-present, salesforce.com, inc. All rights reserved
 // Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license
 
-const { isRelativeSpacing, remToPx } = require("../util");
+const {
+  isRelativeSpacing,
+  isAbsoluteSpacing,
+  remToPx,
+  pxToDp
+} = require("../util");
 
 const convertRemToPx = prop => {
   const baseFontPercentage =
@@ -23,5 +28,9 @@ module.exports = {
   "relative/pixelValue": {
     predicate: prop => isRelativeSpacing(prop.get("value")),
     transform: prop => convertRemToPx(prop).replace(/px$/g, "")
+  },
+  "absolute/dp": {
+    predicate: prop => isAbsoluteSpacing(prop.get("value")),
+    transform: prop => pxToDp(prop.get("value"))
   }
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -32,6 +32,7 @@ const allMatches = (s, pattern) => {
 };
 
 const isRelativeSpacing = value => /rem$/.test(value);
+const isAbsoluteSpacing = value => /px$/.test(value);
 
 const remToPx = (rem, baseFontPercentage, baseFontPixel) =>
   parseFloat(rem.replace(/rem/g, "")) *
@@ -39,12 +40,16 @@ const remToPx = (rem, baseFontPercentage, baseFontPixel) =>
     (baseFontPercentage / 100) +
   "px";
 
+const pxToDp = px => px.replace(/px/g, "") + "dp";
+
 const kebabCase = string => noCase(string, null, "-");
 
 module.exports = {
   allMatches,
   isRelativeSpacing,
+  isAbsoluteSpacing,
   remToPx,
+  pxToDp,
   kebabCase,
   indent,
   comment


### PR DESCRIPTION
As documented on [this page](https://developer.android.com/guide/topics/resources/more-resources#Dimension) Android developers should use Density independent pixels for size definitions.

This PR adapts the XML output to use density independent pixels instead of pixels.

Note: I wasn't able to verify this behavior using a test. It seems that there are no tests that actually use the registered transformations. Could someone help to verify that the changes made in this PR are valid?