### PR TITLE
Convert invalid hyphens to underscores for Android

### DIFF
--- a/lib/formats/android.xml.js
+++ b/lib/formats/android.xml.js
@@ -28,7 +28,7 @@ module.exports = def => {
           [key]: [
             {
               _attr: {
-                name: _.toUpper(prop.get("name")),
+                name: _.toUpper(prop.get("name")).replace(/[-]/g, "_"),
                 category: prop.get("category")
               }
             },


### PR DESCRIPTION
Fixes https://github.com/salesforce-ux/theo/issues/158.

According to the Android developers I work with, hyphens (-) are not valid in resource identifier names. I wasn't able to find an official, specific source verifying this, however, I noted that none of the resource examples https://developer.android.com/guide/topics/resources/providing-resources showed hyphens, while many showed underscores (_). 

[This answer on StackOverflow](https://stackoverflow.com/questions/5949395/naming-rules-for-android-resources) states that Android resource identifier names must conform to the rules for Java identifiers, which are restricted to [letters, digits, underscore, and dollar sign](https://docs.oracle.com/javase/specs/jls/se10/html/jls-3.html#jls-IdentifierChars):

> The "Java letters" include uppercase and lowercase ASCII Latin letters A-Z (\u0041-\u005a), and a-z (\u0061-\u007a), and, for historical reasons, the ASCII dollar sign ($, or \u0024) and underscore (_, or \u005f). The dollar sign should be used only in mechanically generated source code or, rarely, to access pre-existing names on legacy systems. The underscore may be used in identifiers formed of two or more characters, but it cannot be used as a one-character identifier due to being a keyword.

> The "Java digits" include the ASCII digits 0-9 (\u0030-\u0039).

My implementation approach is to specifically address hyphens as a common input and directly convert them to underscores in an attempt to preserve authorial intent. See https://github.com/salesforce-ux/theo/issues/160

Normally, I would have added a test case for something like this, but see https://github.com/salesforce-ux/theo/issues/161.