### PR TITLE
Use OrderedMap to maintain YML input file props order.

### DIFF
--- a/lib/effects.js
+++ b/lib/effects.js
@@ -33,7 +33,12 @@ const resolve = ({ file, data }) =>
     .map(constant({ file, data }))
     .orElse(() => load(file))
     .chain(parse)
-    .map(Immutable.fromJS)
+    .map(v => {
+      // make sure we maintain original order from yml
+      return Immutable.fromJS(v, (key, value, path) => {
+        return value.toOrderedMap()
+      })
+    })
     .map(parsed =>
       Immutable.fromJS({
         global: {},


### PR DESCRIPTION
In our token setup the order of the YML props has a meaning. e.g. colors are grouped by hue. 

As far as I can tell without this patch the order of the output is nondeterministic/scrambled. This is because Immutable.fromJS, at least in our case, converts the input JS array into a non-ordered Map instead of an OrderedMap.

Example.yml
- colorYellow
- colorDarkYellow
- colorGreen

Example.output (without patch)
- $yellow
- $green
- $darkYellow

Example.output (with patch)
- $yellow
- $darkYellow
- $green
