### PR TITLE
Fix missing dependency to commandline arguments parser

### DIFF
--- a/bin/theo.js
+++ b/bin/theo.js
@@ -2,7 +2,7 @@
 // Copyright (c) 2015-present, salesforce.com, inc. All rights reserved
 // Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license
 
-const argv = require("optimist").argv;
+const argv = require("yargs").argv;
 
 const build = require("./scripts/build");
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "no-case": "2.3.2",
     "resolve-from": "5.0.0",
     "tinycolor2": "1.4.1",
-    "xml": "1.0.1"
+    "xml": "1.0.1",
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
     "husky": "^4.2.3",


### PR DESCRIPTION
Adds a direct dependency to commandline arguments parser. As the currently used optimist is deprecated, switching to yargs. 

Closes #216 